### PR TITLE
[update] language menuのコンポーネント化

### DIFF
--- a/angular/src/app/accounts/deposit/deposit.component.ts
+++ b/angular/src/app/accounts/deposit/deposit.component.ts
@@ -12,7 +12,7 @@ import { State } from '../../store/index'
 import { Observable } from 'rxjs';
 import { LanguageService } from '../../services/language.service';
 import { Back, Navigate } from '../../store/router/router.actions';
-import { SendDepositRequest } from 'src/app/store/api/deposit/deposit.actions';
+import { SendDepositRequest } from '../../store/api/deposit/deposit.actions';
 
 @Component({
   selector: 'app-deposit',

--- a/angular/src/app/accounts/wallets/wallets.component.html
+++ b/angular/src/app/accounts/wallets/wallets.component.html
@@ -7,17 +7,7 @@
       </button>
       <span>{{translation.wallets[lang]}}</span>
       <span class="fill-remaining-space"></span>
-      <mat-menu #langMenu="matMenu" [overlapTrigger]="false">
-        <button mat-menu-item (click)="lang = 'en'">
-          English
-        </button>
-        <button mat-menu-item (click)="lang = 'ja'">
-          日本語
-        </button>
-      </mat-menu>
-      <button mat-icon-button [matMenuTriggerFor]="langMenu" yPosition="below">
-        {{lang}}
-      </button>
+      <app-language-menu></app-language-menu>
     </mat-toolbar>
     <div class="mat-typography body-container">
       <mat-spinner *ngIf="loading; else loaded"></mat-spinner>

--- a/angular/src/app/accounts/wallets/wallets.component.ts
+++ b/angular/src/app/accounts/wallets/wallets.component.ts
@@ -12,6 +12,7 @@ import { WalletsService } from '../../../app/services/wallets.service';
 import { Wallet } from '../../../../../firebase/functions/src/models/wallet';
 import { Plan } from '../../../../../firebase/functions/src/models/plan';
 import { UserService } from '../../services/user.service';
+import { LanguageService } from '../../services/language.service';
 import { LoadingDialogComponent } from '../../components/loading-dialog/loading-dialog.component';
 import { Observable } from 'rxjs';
 import { Store } from '@ngrx/store';
@@ -27,8 +28,7 @@ export class WalletsComponent implements OnInit {
 
   //以下レガシー
   public loading = true;
-  get lang() { return lang; }
-  set lang(value) { setLang(value); }
+  public get lang() { return this.language.twoLetter; }
   public wallets!: {
     [id: string]: Wallet
   };
@@ -43,7 +43,8 @@ export class WalletsComponent implements OnInit {
     private dialog: MatDialog,
     private snackBar: MatSnackBar,
     private user: UserService,
-    private wallet: WalletsService
+    private wallet: WalletsService,
+    private language: LanguageService
   ) {
     this.loading$ = store.select(state => state.wallet.loading);
   }

--- a/angular/src/app/app.module.ts
+++ b/angular/src/app/app.module.ts
@@ -70,6 +70,7 @@ import { StoreModule } from '@ngrx/store';
 import { reducers, metaReducers } from './store';
 import { StoreDevtoolsModule } from '@ngrx/store-devtools';
 import { BalanceComponent } from './home/balance/balance.component';
+import { LanguageMenuComponent } from './components/language-menu/language-menu.component';
 
 @NgModule({
   declarations: [
@@ -99,7 +100,8 @@ import { BalanceComponent } from './home/balance/balance.component';
     ContactEditDialogComponent,
     NemAddressInputComponent,
     MultisigComponent,
-    BalanceComponent
+    BalanceComponent,
+    LanguageMenuComponent
   ],
   imports: [
     BrowserModule,

--- a/angular/src/app/components/language-menu/language-menu.component.html
+++ b/angular/src/app/components/language-menu/language-menu.component.html
@@ -1,0 +1,11 @@
+<mat-menu #langMenu="matMenu" [overlapTrigger]="false">
+  <button mat-menu-item (click)="setLanguage('en')">
+    English
+  </button>
+  <button mat-menu-item (click)="setLanguage('ja')">
+    日本語
+  </button>
+</mat-menu>
+<button mat-icon-button [matMenuTriggerFor]="langMenu" yPosition="below">
+  {{lang}}
+</button>

--- a/angular/src/app/components/language-menu/language-menu.component.spec.ts
+++ b/angular/src/app/components/language-menu/language-menu.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { LanguageMenuComponent } from './language-menu.component';
+
+describe('LanguageMenuComponent', () => {
+  let component: LanguageMenuComponent;
+  let fixture: ComponentFixture<LanguageMenuComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ LanguageMenuComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(LanguageMenuComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/angular/src/app/components/language-menu/language-menu.component.ts
+++ b/angular/src/app/components/language-menu/language-menu.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
-import { LanguageService } from '../../services/language.service';
 import { Store } from '@ngrx/store';
+import { LanguageService } from '../../services/language.service';
 import { State } from '../../store/index'
 import { SetLanguage } from '../../store/language/language.actions';
 

--- a/angular/src/app/components/language-menu/language-menu.component.ts
+++ b/angular/src/app/components/language-menu/language-menu.component.ts
@@ -1,0 +1,27 @@
+import { Component, OnInit } from '@angular/core';
+import { LanguageService } from '../../services/language.service';
+import { Store } from '@ngrx/store';
+import { State } from '../../store/index'
+import { SetLanguage } from '../../store/language/language.actions';
+
+@Component({
+  selector: 'app-language-menu',
+  templateUrl: './language-menu.component.html',
+  styleUrls: ['./language-menu.component.css']
+})
+export class LanguageMenuComponent implements OnInit {
+  public get lang() { return this.language.twoLetter; }
+
+  constructor(
+    private store: Store<State>,
+    private language: LanguageService
+  ) { }
+
+  ngOnInit() {
+  }
+
+  public setLanguage(twoLetter: string) {
+    this.store.dispatch(new SetLanguage({ twoLetter: twoLetter })) 
+  }
+
+}

--- a/angular/src/app/home/home.component.html
+++ b/angular/src/app/home/home.component.html
@@ -57,17 +57,7 @@
       <img class="icon" src="assets/images/lcnem.svg" />
       <span>LCNEM Wallet</span>
       <span class="fill-remaining-space"></span>
-      <mat-menu #langMenu="matMenu" [overlapTrigger]="false">
-        <button mat-menu-item (click)="setLanguage('en')">
-          English
-        </button>
-        <button mat-menu-item (click)="setLanguage('ja')">
-          日本語
-        </button>
-      </mat-menu>
-      <button mat-icon-button [matMenuTriggerFor]="langMenu" yPosition="below">
-        {{lang}}
-      </button>
+      <app-language-menu></app-language-menu>
     </mat-toolbar>
     <div class="mat-typography body-container">
       <h3>{{translation.balance[lang]}}</h3>

--- a/angular/src/app/home/home.component.ts
+++ b/angular/src/app/home/home.component.ts
@@ -55,10 +55,6 @@ export class HomeComponent implements OnInit {
   ngOnInit() {
   }
 
-  public setLanguage(twoLetter: string) {
-    this.store.dispatch(new SetLanguage({ twoLetter: twoLetter })) 
-  }
-
   public logout() {
     this.store.dispatch(new Logout());
   }

--- a/angular/src/app/home/home.component.ts
+++ b/angular/src/app/home/home.component.ts
@@ -4,7 +4,7 @@ import { Asset, NEMLibrary, NetworkTypes } from 'nem-library';
 import { Observable, of } from 'rxjs';
 import { map, mergeMap, first } from 'rxjs/operators';
 import { Store } from '@ngrx/store';
-import { State } from '../store/index'
+import { State } from '../store/index';
 import { Logout } from '../store/user/user.actions';
 import { LoadWallets } from '../store/wallet/wallet.actions';
 import { Wallet } from '../store/wallet/wallet.model';

--- a/angular/src/app/transactions/transfer/transfer.component.ts
+++ b/angular/src/app/transactions/transfer/transfer.component.ts
@@ -30,7 +30,7 @@ import { Back } from '../../store/router/router.actions';
 import { LoadBalances } from '../../store/nem/balance/balance.actions';
 import { Invoice } from '../../models/invoice';
 import { nodes } from '../../models/nodes';
-import { WebShareApi } from 'src/app/store/api/share/share.actions';
+import { WebShareApi } from '../../store/api/share/share.actions';
 
 @Component({
   selector: 'app-transfer',


### PR DESCRIPTION
そのままコピーしたはずなのに下記のエラーが出ます。
```
ERROR Error: matMenuTriggerFor: must pass in an mat-menu instance.

    Example:
      <mat-menu #menu="matMenu"></mat-menu>
      <button [matMenuTriggerFor]="menu"></button>
    at throwMatMenuMissingError (menu.es5.js:192)
    at MatMenuTrigger.push../node_modules/@angular/material/esm5/menu.es5.js.MatMenuTrigger._checkMenu (menu.es5.js:1318)
    at MatMenuTrigger.push../node_modules/@angular/material/esm5/menu.es5.js.MatMenuTrigger.openMenu (menu.es5.js:1138)
    at MatMenuTrigger.push../node_modules/@angular/material/esm5/menu.es5.js.MatMenuTrigger.toggleMenu (menu.es5.js:1122)
    at MatMenuTrigger.push../node_modules/@angular/material/esm5/menu.es5.js.MatMenuTrigger._handleClick (menu.es5.js:1533)
    at Object.eval [as handleEvent] (LanguageMenuComponent.html:9)
    at handleEvent (core.js:19628)
    at callWithDebugContext (core.js:20722)
    at Object.debugHandleEvent [as handleEvent] (core.js:20425)
    at dispatchEvent (core.js:17077)
```

あと、importでエラーでてたところ動作確認のために修正しました。